### PR TITLE
remove chunking from mimeparser

### DIFF
--- a/src/mimeparser.js
+++ b/src/mimeparser.js
@@ -33,17 +33,8 @@
      * Creates a parser for a mime stream
      *
      * @constructor
-     * @param {Object} [options] Optional options object
-     * @param {Number} [options.chunkSize=65536] Maximum size of a body chunk to be emitted
      */
-    function MimeParser(options) {
-        options = options || {};
-
-        /**
-         * Maximum size of a body chunk to be emitted
-         */
-        this.chunkSize = options.chunkSize || 64 * 1024;
-
+    function MimeParser() {
         /**
          * Returned to the write calls
          */
@@ -415,7 +406,6 @@
                     this._bodyBuffer += (this._lineCount > 1 ? '\n' : '') + line;
                     break;
             }
-            this._emitBody();
         }
     };
 
@@ -424,18 +414,14 @@
      *
      * @param {Boolean} forceEmit If set to true does not keep any remainders
      */
-    MimeNode.prototype._emitBody = function(forceEmit) {
-        var emitStr = '';
-
-        if (this._state !== 'BODY' || this._isMultipart || !this._bodyBuffer) {
+    MimeNode.prototype._emitBody = function() {
+        if (this._isMultipart || !this._bodyBuffer) {
             return;
         }
 
-        if (forceEmit || this._bodyBuffer.length >= this._parser.chunkSize) {
-            emitStr = this._bodyBuffer.substr(0, this._parser.chunkSize);
-            this._bodyBuffer = this._bodyBuffer.substr(emitStr.length);
-            this._parser.onbody(this, mimefuncs.toArrayBuffer(emitStr));
-        }
+        this.content = mimefuncs.toArrayBuffer(this._bodyBuffer);
+        this._bodyBuffer = '';
+        this._parser.onbody(this, this.content);
     };
 
     return MimeParser;

--- a/test/mimeparser-unit.js
+++ b/test/mimeparser-unit.js
@@ -28,8 +28,14 @@ define(['chai', 'mimeparser'], function(chai, Mimeparser) {
                     expect(new TextDecoder('utf-8').decode(chunk)).to.equal('Hello world!');
                 };
 
-                parser.onend = done;
-                parser.end(fixture);
+                parser.onend = function() {
+                    expect(parser.nodes).to.not.be.empty;
+                    expect(new TextDecoder('utf-8').decode(parser.nodes.node.content)).to.equal('Hello world!');
+
+                    done();
+                };
+                parser.write(fixture);
+                parser.end();
             });
         });
     });


### PR DESCRIPTION
this pull request removes chunking output from the mimeparser. i do not see any advantage in doing this and it makes the code more complex.

when we're done parsing a node, the contents of the respective node are added as an arraybuffer in the attribute 'content' and subsequently returned in _emitBody
