### PR TITLE
format=flowed logic should not corrupt first CRLF

### DIFF
--- a/src/mimeparser.js
+++ b/src/mimeparser.js
@@ -600,14 +600,14 @@
             split('\n').
             // remove soft linebreaks
             // soft linebreaks are added after space symbols
-            reduce(function(previousValue, currentValue, index) {
+            reduce(function(previousValue, currentValue) {
                 var body = previousValue;
                 if (delSp) {
                     // delsp adds spaces to text to be able to fold it
                     // these spaces can be removed once the text is unfolded
                     body = body.replace(/[ ]+$/, '');
                 }
-                if (/ $/.test(previousValue) && !/(^|\n)\-\- $/.test(previousValue) ||  index === 1) {
+                if (/ $/.test(previousValue) && !/(^|\n)\-\- $/.test(previousValue)) {
                     return body + currentValue;
                 } else {
                     return body + '\n' + currentValue;

--- a/test/mimeparser-unit.js
+++ b/test/mimeparser-unit.js
@@ -905,6 +905,19 @@
                 parser.end();
             });
 
+            it('should not corrupt format=flowed text that is not flowed', function(done) {
+                var fixture = 'Content-Type: text/plain; format=flowed\r\n\r\nFirst line.\r\nSecond line.\r\n';
+
+                parser.onend = function() {
+                    expect(parser.nodes).to.not.be.empty;
+                    expect(new TextDecoder('utf-8').decode(parser.nodes.node.content)).to.equal('First line.\nSecond line.\n');
+                    done();
+                };
+
+                parser.write(fixture);
+                parser.end();
+            });
+
             it('should parse format=fixed text', function(done) {
                 var fixture = 'Content-Type: text/plain; format=fixed\r\n\r\nFirst line \r\ncontinued \r\nand so on';
 


### PR DESCRIPTION
The (index === 1) check looks like it might have been a temporary hack that
might have been rationalized in the face of the use of "reduce", but seems to
just be incorrect.
