### PR TITLE
utf-8 multibyte characters are corrupted by str2arr

### DIFF
--- a/src/node-unit.js
+++ b/src/node-unit.js
@@ -444,7 +444,7 @@ describe('MimeNode tests', function () {
         params: {}
       }
       node.charset = 'utf-8'
-      var str = node._bodyBuffer = 'Спасибо'
+      node._bodyBuffer = 'Спасибо'
       node._emitBody()
 
       expect(node.content).to.deep.equal(new Uint8Array([0xD0, 0xA1, 0xD0, 0xBF, 0xD0, 0xB0, 0xD1, 0x81, 0xD0, 0xB8, 0xD0, 0xB1, 0xD0, 0xBE]))

--- a/src/node-unit.js
+++ b/src/node-unit.js
@@ -437,6 +437,18 @@ describe('MimeNode tests', function () {
       expect(node.content).to.deep.equal(new Uint8Array([0xC5, 0xBE, 0xC5, 0xA1]))
       expect(node.charset).to.equal('utf-8')
     })
+
+    it('should properly convert multibyte characters', function () {
+      node.contentType = {
+        value: 'text/html',
+        params: {}
+      }
+      node.charset = 'utf-8'
+      var str = node._bodyBuffer = 'Спасибо'
+      node._emitBody()
+
+      expect(node.content).to.deep.equal(new Uint8Array([0xD0, 0xA1, 0xD0, 0xBF, 0xD0, 0xB0, 0xD1, 0x81, 0xD0, 0xB8, 0xD0, 0xB1, 0xD0, 0xBE]))
+    })
   })
 
   describe('#_detectHTMLCharset', function () {

--- a/src/node.js
+++ b/src/node.js
@@ -1,6 +1,6 @@
 import { pathOr } from 'ramda'
 import timezone from './timezones'
-import { decode, base64Decode, convert, parseHeaderValue, mimeWordsDecode } from 'emailjs-mime-codec'
+import { encode, decode, base64Decode, convert, parseHeaderValue, mimeWordsDecode } from 'emailjs-mime-codec'
 import parseAddress from 'emailjs-addressparser'
 
 export default class MimeNode {
@@ -310,7 +310,7 @@ export default class MimeNode {
     }
 
     this._processFlowedText()
-    this.content = str2arr(this._bodyBuffer)
+    this.content = (/^utf/i.test(this.charset) ? encode : str2arr)(this._bodyBuffer)
     this._processHtmlText()
     this._bodyBuffer = ''
   }


### PR DESCRIPTION
Hi!
Multibyte characters are corrupted after `str2arr` conversion. Usage of `encode` fixes that. I'm not sure that this pull request is a general solution but at least it depicts the problem.