### PR TITLE
Default charset to binary for non-text/* attachments if charset is not defined

### DIFF
--- a/src/node-unit.js
+++ b/src/node-unit.js
@@ -255,6 +255,108 @@ describe('MimeNode tests', function () {
       expect(node._isMultipart).to.equal('mixed')
       expect(node._multipartBoundary).to.equal('zzzz')
     })
+
+    it('should set charset to binary for attachment when there is no charset', function () {
+      node.headers['content-type'] = [{
+        value: 'application/pdf'
+      }]
+
+      node.headers['content-disposition'] = [{
+        value: 'attachment'
+      }]
+
+      node._processContentType()
+
+      expect(node.contentType).to.deep.equal({
+        value: 'application/pdf',
+        type: 'application'
+      })
+      expect(node.charset).to.equal('binary')
+    })
+
+    it('should set charset to binary for inline attachment when there is no charset', function () {
+      node.headers['content-type'] = [{
+        value: 'image/png'
+      }]
+
+      node.headers['content-disposition'] = [{
+        value: 'inline'
+      }]
+
+      node._processContentType()
+
+      expect(node.contentType).to.deep.equal({
+        value: 'image/png',
+        type: 'image'
+      })
+      expect(node.charset).to.equal('binary')
+    })
+
+    it('should not set charset to binary for inline attachment when there is a charset', function () {
+      node.headers['content-type'] = [{
+        value: 'image/png',
+        params: {
+          charset: 'US-ASCII'
+        }
+      }]
+
+      node.headers['content-disposition'] = [{
+        value: 'inline'
+      }]
+
+      node._processContentType()
+
+      expect(node.contentType).to.deep.equal({
+        value: 'image/png',
+        type: 'image',
+        params: {
+          charset: 'US-ASCII'
+        }
+      })
+      expect(node.charset).to.equal('US-ASCII')
+    })
+
+    it('should not set charset to binary for text/* attachment when there is no charset', function () {
+      node.headers['content-type'] = [{
+        value: 'text/plain'
+      }]
+
+      node.headers['content-disposition'] = [{
+        value: 'attachment'
+      }]
+
+      node._processContentType()
+
+      expect(node.contentType).to.deep.equal({
+        value: 'text/plain',
+        type: 'text'
+      })
+      expect(node.charset).to.be.undefined
+    })
+
+    it('should not set charset to binary for text/* attachment when there is a charset', function () {
+      node.headers['content-type'] = [{
+        value: 'text/plain',
+        params: {
+          charset: 'US-ASCII'
+        }
+      }]
+
+      node.headers['content-disposition'] = [{
+        value: 'attachment'
+      }]
+
+      node._processContentType()
+
+      expect(node.contentType).to.deep.equal({
+        value: 'text/plain',
+        type: 'text',
+        params: {
+          charset: 'US-ASCII'
+        }
+      })
+      expect(node.charset).to.equal('US-ASCII')
+    })
   })
 
   describe('#_processContentTransferEncoding', function () {


### PR DESCRIPTION
Issue: https://github.com/emailjs/emailjs-mime-parser/issues/18

Hi @felixhammerl : I ran into the same issues discussed in the above link. Seems like any attachment (inline/regular) from popular clients like gmail/outlook do not have charset for the attachment node's content-type. This causes UTF-8 to be picked as default charset (instead of binary) and thereby the attachment is not decoded correctly. 

To fix this I created this pull request where I'm defaulting the charset to binary for non-text/* attachments, when no charset is present - I think this is kinda inline with your proposal in the issue #18. 

Could you please review and let me know if you suggest any changes or merge if it looks good!

Thank you,
Mahesh.