### PR TITLE
WIP: Base64 encoded Japanese character not decoded as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "main": "dist/mimeparser",
   "dependencies": {
     "emailjs-addressparser": "^2.0.1",
+    "emailjs-base64": "^1.1.2",
     "emailjs-mime-codec": "^2.0.7",
     "ramda": "^0.25.0"
   },

--- a/src/mimeparser-unit.js
+++ b/src/mimeparser-unit.js
@@ -118,6 +118,23 @@ describe('message tests', function () {
     })
   })
 
+  it('should parse UTF-8 encoded body with Base64 transfer encoding', function () {
+    var fixture = 'Mime-Version: 1.0\r\n' +
+    'Content-Type: text/plain; charset=UTF-8\r\n' +
+    'Content-Transfer-Encoding: base64\r\n' +
+    '\r\n' +
+    'CuKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKU\r\n' +
+    'geKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKUgeKU\r\n' +
+    'geKUgeKUgQoK44CA44CA44CA44CA44CA44CA44CAWWFob28h44Kr44O844OJ\r\n' +
+    '44CA44GK44GZ44GZ44KB5oOF5aCx44Oh44O844Or\r\n'
+    const root = parse(fixture)
+    expect(new TextDecoder('utf-8').decode(root.content)).to.equal(
+      '\n' +
+      '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+      '\n' +
+      '　　　　　　　Yahoo!カード　おすすめ情報メール')
+  })
+
   it('should decode plaintext body from latin-1 charset', function () {
     var fixture = 'Content-Type: text/plain; charset="latin_1"\r\n' +
       'Content-Transfer-Encoding: quoted-printable\r\n' +

--- a/src/node.js
+++ b/src/node.js
@@ -1,6 +1,7 @@
 import { pathOr } from 'ramda'
 import timezone from './timezones'
-import { decode, base64Decode, convert, parseHeaderValue, mimeWordsDecode } from 'emailjs-mime-codec'
+import { decode, convert, parseHeaderValue, mimeWordsDecode } from 'emailjs-mime-codec'
+import { decode as decodeBase64 } from 'emailjs-base64'
 import parseAddress from 'emailjs-addressparser'
 
 export default class MimeNode {
@@ -283,7 +284,7 @@ export default class MimeNode {
           }
 
           if (curLine.length) {
-            this._bodyBuffer += base64Decode(curLine, this.charset)
+            this._bodyBuffer += decodeBase64(curLine)
           }
 
           break


### PR DESCRIPTION
Fixes #35, regressed in dd673102582af6c6315c1643d8c19b6e83b6f8a7

Revert back to emailjs-base64's decode.

TODO: deal with unit test from dd67310.